### PR TITLE
Implement iterable interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "test": "node test/.test.js"
   },
   "devDependencies": {
+    "jshint": "^2.9.1",
+    "uglify-js": "^2.6.2",
     "wru": ">= 0.0.0"
   }
 }

--- a/src/url-search-params.js
+++ b/src/url-search-params.js
@@ -44,8 +44,17 @@ var
   replacer = function (match) {
     return replace[match];
   },
+  iterable = isIterable(),
   secret = '__URLSearchParams__:' + Math.random()
 ;
+
+function isIterable() {
+  try {
+    return !!Symbol.iterator;
+  } catch(error) {
+    return false;
+  }
+}
 
 URLSearchParamsProto.append = function append(name, value) {
   var dict = this[secret];
@@ -77,6 +86,76 @@ URLSearchParamsProto.has = function has(name) {
 URLSearchParamsProto.set = function set(name, value) {
   this[secret][name] = ['' + value];
 };
+
+URLSearchParamsProto.forEach = function forEach(callback, thisArg) {
+  var dict = this[secret];
+  Object.getOwnPropertyNames(dict).forEach(function(name) {
+    dict[name].forEach(function(value) {
+      callback.call(thisArg, value, name, this);
+    }, this);
+  }, this);
+};
+
+URLSearchParamsProto.keys = function keys() {
+  var items = [];
+  this.forEach(function(value, name) { items.push(name); });
+  var iterator = {
+    next: function() {
+      var value = items.shift();
+      return {done: value === undefined, value: value};
+    }
+  };
+
+  if (iterable) {
+    iterator[Symbol.iterator] = function() {
+      return iterator;
+    };
+  }
+
+  return iterator;
+};
+
+URLSearchParamsProto.values = function values() {
+  var items = [];
+  this.forEach(function(value) { items.push(value); });
+  var iterator = {
+    next: function() {
+      var value = items.shift();
+      return {done: value === undefined, value: value};
+    }
+  };
+
+  if (iterable) {
+    iterator[Symbol.iterator] = function() {
+      return iterator;
+    };
+  }
+
+  return iterator;
+};
+
+URLSearchParamsProto.entries = function entries() {
+  var items = [];
+  this.forEach(function(value, name) { items.push([name, value]); });
+  var iterator = {
+    next: function() {
+      var value = items.shift();
+      return {done: value === undefined, value: value};
+    }
+  };
+
+  if (iterable) {
+    iterator[Symbol.iterator] = function() {
+      return iterator;
+    };
+  }
+
+  return iterator;
+};
+
+if (iterable) {
+  URLSearchParamsProto[Symbol.iterator] = URLSearchParamsProto.entries;
+}
 
 /*
 URLSearchParamsProto.toBody = function() {

--- a/test/url-search-params.js
+++ b/test/url-search-params.js
@@ -62,6 +62,96 @@ wru.test([
       wru.assert('correct escaping', usp.toString() === 'a=12%3D3');
       wru.assert('correct value', usp.get('a') === '12=3');
     }
+  }, {
+    name: 'iterating with keys',
+    test: function () {
+      var usp = new URLSearchParams('a=1&a=2&b=3');
+      var iterator = usp.keys()
+
+      var next = iterator.next();
+      wru.assert('correct iterator value', !next.done);
+      wru.assert('correct iterator value', next.value === 'a');
+
+      next = iterator.next();
+      wru.assert('correct iterator value', !next.done);
+      wru.assert('correct iterator value', next.value === 'a');
+
+      next = iterator.next();
+      wru.assert('correct iterator value', !next.done);
+      wru.assert('correct iterator value', next.value === 'b');
+
+      next = iterator.next();
+      wru.assert('correct iterator value', next.done);
+      wru.assert('correct iterator value', next.value === undefined);
+    }
+  }, {
+    name: 'iterating with values',
+    test: function () {
+      var usp = new URLSearchParams('a=1&a=2&b=3');
+      var iterator = usp.values()
+
+      var next = iterator.next();
+      wru.assert('correct iterator value', !next.done);
+      wru.assert('correct iterator value', next.value === '1');
+
+      next = iterator.next();
+      wru.assert('correct iterator value', !next.done);
+      wru.assert('correct iterator value', next.value === '2');
+
+      next = iterator.next();
+      wru.assert('correct iterator value', !next.done);
+      wru.assert('correct iterator value', next.value === '3');
+
+      next = iterator.next();
+      wru.assert('correct iterator value', next.done);
+      wru.assert('correct iterator value', next.value === undefined);
+    }
+  }, {
+    name: 'iterating with entries',
+    test: function () {
+      var usp = new URLSearchParams('a=1&a=2&b=3');
+      var iterator = usp.entries()
+
+      var next = iterator.next();
+      wru.assert('correct iterator value', !next.done);
+      wru.assert('correct iterator value', next.value[0] === 'a' && next.value[1] === '1');
+
+      next = iterator.next();
+      wru.assert('correct iterator value', !next.done);
+      wru.assert('correct iterator value', next.value[0] === 'a' && next.value[1] === '2');
+
+      next = iterator.next();
+      wru.assert('correct iterator value', !next.done);
+      wru.assert('correct iterator value', next.value[0] === 'b' && next.value[1] === '3');
+
+      next = iterator.next();
+      wru.assert('correct iterator value', next.done);
+      wru.assert('correct iterator value', next.value === undefined);
+    }
+  }, {
+    name: 'iterating with forEach',
+    test: function () {
+      var usp = new URLSearchParams('a=1&a=2&b=3');
+
+      var results = [];
+      usp.forEach(function(value, key, object) {
+        results.push({value: value, key: key, object: object});
+      });
+
+      wru.assert('correct loop count', results.length === 3);
+
+      wru.assert('correct loop key', results[0].key === 'a');
+      wru.assert('correct loop value', results[0].value === '1');
+      wru.assert('correct loop object', results[0].object === usp);
+
+      wru.assert('correct loop key', results[1].key === 'a');
+      wru.assert('correct loop value', results[1].value === '2');
+      wru.assert('correct loop object', results[1].object === usp);
+
+      wru.assert('correct loop key', results[2].key === 'b');
+      wru.assert('correct loop value', results[2].value === '3');
+      wru.assert('correct loop object', results[2].object === usp);
+    }
   }
 ].concat(
   /^function|object$/.test(typeof HTMLAnchorElement) && ('searchParams' in HTMLAnchorElement.prototype) ?


### PR DESCRIPTION
Adds all iterator methods from the iterable interface:

- forEach
- keys
- values
- entries

If `Symbol.iterator` is available, the `URLSearchParams` object itself may be used in a `for…of` loop.

```js
for (var entry of searchParams) {
  console.log(entry)
}
```

This matches the behavior of Chrome and Firefox.

https://url.spec.whatwg.org/#urlsearchparams
http://heycam.github.io/webidl/#idl-iterable
http://heycam.github.io/webidl/#es-iterable