### PR TITLE
Fixed failed tests on IE 11 - URL.prototype is undefined

### DIFF
--- a/src/upgrades.js
+++ b/src/upgrades.js
@@ -1,6 +1,6 @@
 
 upgradeClass(HTMLAnchorElement);
-if (/^function|object$/.test(typeof URL)) upgradeClass(URL);
+if (/^function|object$/.test(typeof URL) && URL.prototype) upgradeClass(URL);
 
 /*
 


### PR DESCRIPTION
On IE11 URl object has no prototype