### PR TITLE
Allow `.amd.js` builds in package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,5 @@ src/*
 test/*
 template/*
 node_modules/*
-build/*.amd.js
 Makefile
 index.html


### PR DESCRIPTION
Is there a reason these are explicitly excluded?